### PR TITLE
fix: display all news without pagination

### DIFF
--- a/src/app/(components)/(elements)/NewsItem.tsx
+++ b/src/app/(components)/(elements)/NewsItem.tsx
@@ -8,7 +8,11 @@ import { useState } from 'react';
 import NoImage from '../../../../public/images/noImage.png';
 
 export default function NewsItem({ data }: { data: NewsDataType }) {
-  const [src, setSrc] = useState(`${constants.baseUrl}${data.coverImage}`);
+  const [src, setSrc] = useState(
+    !data.coverImage?.startsWith('https://')
+      ? `${constants.baseUrl}${data.coverImage}`
+      : data.coverImage
+  );
   return (
     <Link
       href={'news/' + data.id}

--- a/src/core/api/apiConstants.ts
+++ b/src/core/api/apiConstants.ts
@@ -40,6 +40,6 @@ export const apiPaths = {
     getSociallinkUrl: '/socialLink/v2',
     getGeneralUrl: '/general/general-mutation',
     getVolutneryHazardUrl: '/general/hazard',
-    getNewsUrl: '/news',
+    getNewsUrl: '/news/',
     footerUrl: '/footer/'
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,11 +3650,6 @@ next-auth@^4.24.7:
     preact-render-to-string "^5.1.19"
     uuid "^8.3.2"
 
-next-seo@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-6.6.0.tgz#10c6278cc3be51f9db1ede6780812e5664742974"
-  integrity sha512-0VSted/W6XNtgAtH3D+BZrMLLudqfm0D5DYNJRXHcDgan/1ZF1tDFIsWrmvQlYngALyphPfZ3ZdOqlKpKdvG6w==
-
 next@14.2.3:
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/next/-/next-14.2.3.tgz#f117dd5d5f20c307e7b8e4f9c1c97d961008925d"


### PR DESCRIPTION
## Summary by Sourcery

Updates the news API endpoint to display all news items without pagination and ensures correct image URL handling.

Bug Fixes:
- Fixes an issue where news items were paginated, now displaying all items.
- Ensures that image URLs starting with 'https://' are correctly handled.