### PR TITLE
fix: loading state in voluntary hazard form

### DIFF
--- a/src/app/(home)/voluntary-hazard-report/(components)/Form.tsx
+++ b/src/app/(home)/voluntary-hazard-report/(components)/Form.tsx
@@ -25,6 +25,7 @@ const Forms = () => {
   };
 
   const onSubmit = (values: HazardFormType) => {
+    if (isLoading) return;
     setIsLoading(true);
     try {
       const responseData = dispatch(
@@ -171,7 +172,7 @@ const Forms = () => {
         <div className="form-field">
           <div />
           <button className="button-outline-light" type="submit">
-            Submit
+            {isLoading ? 'Submitting...' : 'Submit'}
           </button>
         </div>
       </form>


### PR DESCRIPTION
## Summary by Sourcery

Improve loading state handling in the voluntary hazard report form to prevent multiple submissions and provide user feedback

Bug Fixes:
- Prevent multiple form submissions by adding a loading state check before submission
- Update submit button text to reflect the current loading state of the form